### PR TITLE
Update cheerio dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -39,7 +39,7 @@
     }
   },
   "dependencies": {
-    "cheerio": "^0.17.0",
+    "cheerio": "^0.19.0",
     "lodash": "^2.4.1",
     "minimist": "^1.1.0"
   }


### PR DESCRIPTION
removes warning about deprecated deps
(CSSselect, CSSwhat)
